### PR TITLE
Add published field to cordel and a dto to fix sonar issues

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -6,7 +6,7 @@ info:
   title: "E-cordel API"
   contact:
     name: Mário Sousa
-    url: http://itsmemario.com.br
+    url: http://ecordel.com.br
     email: super.mario.santos.sousa@gmail.com
 
 servers:
@@ -35,6 +35,12 @@ paths:
             type: string
           required: false
           description: search corldels with titles that contains the parameter. It will work such as a like operation.
+        - name: published
+          in: query
+          schema:
+            type: boolean
+          required: false
+          description: search only publish corldels. This parameter is always true if is omitted.
       responses:
         200:
           description: "successful operation"

--- a/pom.xml
+++ b/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>br.com.itsmemario</groupId>
     <artifactId>ecordel</artifactId>
-    <version>0.2.0-SNAPSHOT</version>
+    <version>0.3.0-SNAPSHOT</version>
     <name>e-cordel</name>
     <description>e-reader for cordels</description>
 

--- a/src/main/java/br/com/itsmemario/ecordel/author/Author.java
+++ b/src/main/java/br/com/itsmemario/ecordel/author/Author.java
@@ -33,7 +33,7 @@ public class Author implements AuthorView {
     private String email;
 
     public static Author of( Long id ) {
-        Author author = new Author();
+        var author = new Author();
         author.id = id;
         return author;
     }

--- a/src/main/java/br/com/itsmemario/ecordel/author/Author.java
+++ b/src/main/java/br/com/itsmemario/ecordel/author/Author.java
@@ -23,7 +23,7 @@ import javax.persistence.GenerationType;
 import javax.persistence.Id;
 
 @Entity
-public class Author implements AuthorView{
+public class Author implements AuthorView {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -31,6 +31,12 @@ public class Author implements AuthorView{
     private String name;
     private String about;
     private String email;
+
+    public static Author of( Long id ) {
+        Author author = new Author();
+        author.id = id;
+        return author;
+    }
 
     public Long getId() {
         return id;

--- a/src/main/java/br/com/itsmemario/ecordel/author/AuthorDto.java
+++ b/src/main/java/br/com/itsmemario/ecordel/author/AuthorDto.java
@@ -25,7 +25,7 @@ public class AuthorDto {
     private Long id;
 
     public Author toEntity() {
-        Author author = new Author();
+        var author = new Author();
         author.setId(id);
         return author;
     }

--- a/src/main/java/br/com/itsmemario/ecordel/author/AuthorDto.java
+++ b/src/main/java/br/com/itsmemario/ecordel/author/AuthorDto.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2021 Projeto e-cordel (http://ecordel.com.br)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package br.com.itsmemario.ecordel.author;
+
+import lombok.Data;
+
+@Data
+public class AuthorDto {
+
+    private Long id;
+
+    public Author toEntity() {
+        Author author = new Author();
+        author.setId(id);
+        return author;
+    }
+}

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/Cordel.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/Cordel.java
@@ -45,6 +45,7 @@ public class Cordel implements CordelView {
 	@ElementCollection
 	@CollectionTable(name = "cordel_tags")
 	private Set<String> tags;
+	private boolean published;
 
 	Cordel() {}
 
@@ -108,6 +109,14 @@ public class Cordel implements CordelView {
 
 	public void setTags(Set<String> tags) {
 		this.tags = tags;
+	}
+
+	public boolean isPublished() {
+		return published;
+	}
+
+	public void setPublished(boolean published) {
+		this.published = published;
 	}
 
 	@Override

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CordelController.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CordelController.java
@@ -29,7 +29,6 @@ import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.validation.Valid;
-import java.net.URI;
 import java.util.Optional;
 
 @RestController
@@ -59,9 +58,9 @@ public class CordelController {
     }
 
     @GetMapping
-    public Page<CordelSummary> getPublishedCordels(@RequestParam(required = false) String title,
-                                                   @RequestParam(defaultValue = "true") boolean published,
-                                                   Pageable pageable) {
+    public Page<CordelSummary> getCordels(@RequestParam(required = false) String title,
+                                          @RequestParam(defaultValue = "true") boolean published,
+                                          Pageable pageable) {
         logger.info("request received get cordels");
         return service.findPublishedByTitle(published, title, pageable);
     }
@@ -71,7 +70,7 @@ public class CordelController {
         logger.info("request received for create cordel: {}", dto);
 
         service.save(dto.toEntity());
-        URI uri = uriBuilder.path("/cordels/{id}").buildAndExpand(dto.getId()).toUri();
+        var uri = uriBuilder.path("/cordels/{id}").buildAndExpand(dto.getId()).toUri();
         logger.info("new cordel Location header: {}", uri.getPath());
         return ResponseEntity.created(uri).build();
     }
@@ -92,11 +91,10 @@ public class CordelController {
             return ResponseEntity.notFound().build();
         }
 
-        Cordel newData = dto.toEntity();
-        newData.setId(id);
-        Cordel newCordel = service.save(newData);
+        var cordel = dto.toEntity();
+        cordel.setId(id);
 
-        return ResponseEntity.ok(newCordel);
+        return ResponseEntity.ok(service.save(cordel));
     }
 
 }

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CordelController.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CordelController.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Projeto e-cordel (http://ecordel.com.br)
+ * Copyright 2020-2021 Projeto e-cordel (http://ecordel.com.br)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -35,62 +35,68 @@ import java.util.Optional;
 @RestController
 @RequestMapping("cordels")
 public class CordelController {
-	
-	private final Logger logger = LoggerFactory.getLogger(CordelController.class);
 
-	private CordelService service;
+    private final Logger logger = LoggerFactory.getLogger(CordelController.class);
 
-	@Autowired
-	CordelController(CordelService service) {
-		this.service = service;
-	}
+    private CordelService service;
 
-	@GetMapping("{id}")
-	public ResponseEntity<Cordel> getCordel(@PathVariable Long id) {
-		logger.info("request received get cordel by id: {}", id);
+    @Autowired
+    CordelController(CordelService service) {
+        this.service = service;
+    }
 
-		Optional<Cordel> cordel = service.findById(id);
-		if(cordel.isPresent()){
-			return ResponseEntity.ok(cordel.get());
-		}else {
-			logger.info("cordel with id {} not fond",id);
-			return ResponseEntity.notFound().build();
-		}
-	}
+    @GetMapping("{id}")
+    public ResponseEntity<Cordel> getCordel(@PathVariable Long id) {
+        logger.info("request received get cordel by id: {}", id);
 
-	@GetMapping
-	public Page<CordelSummary> getCordels(@RequestParam(required = false) String title, Pageable pageable){
-		logger.info("request received get cordels");
-		return service.findByTitle(title, pageable);
-	}
-	
-	@PostMapping
-	public ResponseEntity<Cordel> create(@RequestBody @Valid Cordel cordel, UriComponentsBuilder uriBuilder){
-		logger.info("request received for create cordel: {}", cordel);
-		service.save(cordel);
-		URI uri = uriBuilder.path("/cordels/{id}").buildAndExpand(cordel.getId()).toUri();
-		logger.info("new cordel Location header: {}", uri.getPath());
-		return ResponseEntity.created(uri).build();
-	}
+        Optional<Cordel> cordel = service.findById(id);
+        if (cordel.isPresent()) {
+            return ResponseEntity.ok(cordel.get());
+        } else {
+            logger.info("cordel with id {} not fond", id);
+            return ResponseEntity.notFound().build();
+        }
+    }
 
-	@PutMapping("{id}/xilogravura")
-	public ResponseEntity<Cordel> putXilogravura(@PathVariable Long id, Xilogravura xilogravura, @RequestParam("file") MultipartFile file){
-		logger.info("request received, update xilogravura for cordel: {}", id);
+    @GetMapping
+    public Page<CordelSummary> getPublishedCordels(@RequestParam(required = false) String title,
+                                                   @RequestParam(defaultValue = "true") boolean published,
+                                                   Pageable pageable) {
+        logger.info("request received get cordels");
+        return service.findPublishedByTitle(published, title, pageable);
+    }
 
-		Cordel cordel = service.updateXilogravura(id, xilogravura, file);
-		return ResponseEntity.ok(cordel);
-	}
+    @PostMapping
+    public ResponseEntity<String> create(@RequestBody @Valid CordelDto dto, UriComponentsBuilder uriBuilder) {
+        logger.info("request received for create cordel: {}", dto);
 
-	@PutMapping("{id}")
-	public ResponseEntity<Cordel> update(@RequestBody @Valid Cordel cordel, @PathVariable Long id){
-		logger.info("request received update cordel with id: {}", id);
-		Optional<Cordel> existingCordel = service.findById(id);
-		if(!existingCordel.isPresent()){
-			return ResponseEntity.notFound().build();
-		}
-		cordel.setId(id);
-		Cordel newCordel = service.save(cordel);
-		return ResponseEntity.ok(newCordel);
-	}
+        service.save(dto.toEntity());
+        URI uri = uriBuilder.path("/cordels/{id}").buildAndExpand(dto.getId()).toUri();
+        logger.info("new cordel Location header: {}", uri.getPath());
+        return ResponseEntity.created(uri).build();
+    }
+
+    @PutMapping("{id}/xilogravura")
+    public ResponseEntity<Cordel> putXilogravura(@PathVariable Long id, Xilogravura xilogravura, @RequestParam("file") MultipartFile file) {
+        logger.info("request received, update xilogravura for cordel: {}", id);
+        Cordel cordel = service.updateXilogravura(id, xilogravura, file);
+        return ResponseEntity.ok(cordel);
+    }
+
+    @PutMapping("{id}")
+    public ResponseEntity<Cordel> update(@RequestBody @Valid CordelDto dto, @PathVariable Long id) {
+        logger.info("request received update cordel with id: {}", id);
+
+        Optional<Cordel> existingCordel = service.findById(id);
+        if (existingCordel.isEmpty()) {
+            return ResponseEntity.notFound().build();
+        }
+
+        Cordel newData = dto.toEntity();
+        newData.setId(id);
+        Cordel newCordel = service.save(newData);
+
+        return ResponseEntity.ok(newCordel);
+    }
 
 }

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CordelDto.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CordelDto.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2021 Projeto e-cordel (http://ecordel.com.br)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package br.com.itsmemario.ecordel.cordel;
+
+import br.com.itsmemario.ecordel.author.Author;
+import lombok.Data;
+
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import java.util.Set;
+
+/**
+ * Class used to represent data sent do the backend.
+ */
+@Data
+public class CordelDto {
+
+    private Long id;
+    @NotNull
+    private Long authorId;
+    @NotBlank
+    private String title;
+    @NotBlank
+    private String description;
+    @NotBlank
+    private String content;
+    private boolean published;
+    private Set<String> tags;
+
+    public Cordel toEntity() {
+        Cordel cordel = new Cordel();
+        cordel.setId( id );
+        cordel.setAuthor( Author.of( authorId ) );
+        cordel.setTitle( title );
+        cordel.setDescription( description );
+        cordel.setContent( content );
+        cordel.setPublished( published );
+        cordel.setTags( tags );
+        return cordel;
+    }
+
+}

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CordelDto.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CordelDto.java
@@ -17,7 +17,7 @@
 
 package br.com.itsmemario.ecordel.cordel;
 
-import br.com.itsmemario.ecordel.author.Author;
+import br.com.itsmemario.ecordel.author.AuthorDto;
 import lombok.Data;
 
 import javax.validation.constraints.NotBlank;
@@ -32,7 +32,7 @@ public class CordelDto {
 
     private Long id;
     @NotNull
-    private Long authorId;
+    private AuthorDto author;
     @NotBlank
     private String title;
     @NotBlank
@@ -43,9 +43,9 @@ public class CordelDto {
     private Set<String> tags;
 
     public Cordel toEntity() {
-        Cordel cordel = new Cordel();
+        var cordel = new Cordel();
         cordel.setId( id );
-        cordel.setAuthor( Author.of( authorId ) );
+        cordel.setAuthor( author.toEntity() );
         cordel.setTitle( title );
         cordel.setDescription( description );
         cordel.setContent( content );

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CordelService.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CordelService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Projeto e-cordel (http://ecordel.com.br)
+ * Copyright 2020-2021 Projeto e-cordel (http://ecordel.com.br)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,8 +19,6 @@ package br.com.itsmemario.ecordel.cordel;
 
 import br.com.itsmemario.ecordel.xilogravura.Xilogravura;
 import br.com.itsmemario.ecordel.xilogravura.XilogravuraService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -32,8 +30,6 @@ import java.util.Optional;
 
 @Service
 public class CordelService {
-
-	private final Logger logger = LoggerFactory.getLogger(CordelService.class);
 
 	private CordelRepository repository;
 	private XilogravuraService xilogravuraService;
@@ -48,7 +44,7 @@ public class CordelService {
 	public Page<CordelView> getCordels(Pageable pageable) {
 		return repository.findAllProjectedBy(pageable);
 	}
-	
+
 	public Cordel save(Cordel cordel) {
 		return repository.save(cordel);
 	}
@@ -61,8 +57,8 @@ public class CordelService {
 		return repository.findById(id);
 	}
 
-	public Page<CordelSummary> findByTitle(String title, Pageable pageable) {
-		return repository.findByTitleLike(title, pageable);
+	public Page<CordelSummary> findPublishedByTitle(boolean published, String title, Pageable pageable) {
+		return repository.findPublishedByTitleLike(published, title, pageable);
 	}
 
 	public Cordel updateXilogravura(Long cordelId, Xilogravura xilogravura, MultipartFile file) {

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CustomCordelRepository.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CustomCordelRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Projeto e-cordel (http://ecordel.com.br)
+ * Copyright 2020-2021 Projeto e-cordel (http://ecordel.com.br)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -26,5 +26,5 @@ interface CustomCordelRepository {
 
     Page<CordelView> findByTags(List<String> tags, Pageable pageable);
 
-    Page<CordelSummary> findByTitleLike(String title, Pageable pageable);
+    Page<CordelSummary> findPublishedByTitleLike(boolean published, String title, Pageable pageable);
 }

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CustomCordelRepositoryImpl.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CustomCordelRepositoryImpl.java
@@ -26,7 +26,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 import javax.persistence.PersistenceContext;
-import javax.persistence.Query;
 import javax.persistence.TypedQuery;
 import java.math.BigInteger;
 import java.util.List;

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CustomCordelRepositoryImpl.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CustomCordelRepositoryImpl.java
@@ -70,7 +70,7 @@ class CustomCordelRepositoryImpl implements CustomCordelRepository {
         long count = countResults(tags);
         if(count == 0) return Page.empty(pageable);
 
-        Query query = entityManager.createNativeQuery(FIND_BY_TAGS_SQL);
+        var query = entityManager.createNativeQuery(FIND_BY_TAGS_SQL);
         query.setParameter(TAGS, tags);
         query.setParameter(LIMIT, pageable.getPageSize());
         query.setParameter(OFFSET, pageable.getOffset());
@@ -133,7 +133,7 @@ class CustomCordelRepositoryImpl implements CustomCordelRepository {
     }
 
     private <T> TypedQuery<T> addTitleFilter(String title, StringBuilder sql, Class<T> clazz) {
-        String where = " AND lower(c.title) LIKE lower( :title ) ";
+        var where = " AND lower(c.title) LIKE lower( :title ) ";
         TypedQuery<T> query;
         sql.append(where);
         query = entityManager.createQuery(sql.toString(), clazz);

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CustomCordelRepositoryImpl.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CustomCordelRepositoryImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Projeto e-cordel (http://ecordel.com.br)
+ * Copyright 2020-2021 Projeto e-cordel (http://ecordel.com.br)
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -53,9 +53,14 @@ class CustomCordelRepositoryImpl implements CustomCordelRepository {
 
     private static final String FIND_BY_TAGS_SQL_COUNT = "select COUNT(distinct(c.id)) " + FIND_BY_TAGS_SQL_FROM ;
 
-    private static final String CORDEL_SUMMARY = "SELECT new br.com.itsmemario.ecordel.cordel.CordelSummary(c.id, c.title, x.url, a.name) FROM Cordel c JOIN c.author a LEFT JOIN c.xilogravura x";
-    private static final String COUNT_CORDEL_SUMMARY = "SELECT COUNT(c.id) FROM Cordel c JOIN c.author a LEFT JOIN c.xilogravura x";
-    public static final String TITLE = "title";
+    private static final String CORDEL_SUMMARY = " SELECT new br.com.itsmemario.ecordel.cordel.CordelSummary(c.id, c.title, x.url, a.name) " +
+            " FROM Cordel c JOIN c.author a LEFT JOIN c.xilogravura x WHERE c.published = :published ";
+
+    private static final String COUNT_CORDEL_SUMMARY = "SELECT COUNT(c.id) FROM Cordel c JOIN c.author a " +
+            " LEFT JOIN c.xilogravura x WHERE c.published = :published ";
+
+    private static final String TITLE = "title";
+    public static final String PUBLISHED = "published";
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -65,7 +70,7 @@ class CustomCordelRepositoryImpl implements CustomCordelRepository {
         long count = countResults(tags);
         if(count == 0) return Page.empty(pageable);
 
-        Query query = entityManager.createNativeQuery(this.FIND_BY_TAGS_SQL);
+        Query query = entityManager.createNativeQuery(FIND_BY_TAGS_SQL);
         query.setParameter(TAGS, tags);
         query.setParameter(LIMIT, pageable.getPageSize());
         query.setParameter(OFFSET, pageable.getOffset());
@@ -97,7 +102,7 @@ class CustomCordelRepositoryImpl implements CustomCordelRepository {
     }
 
     @Override
-    public Page<CordelSummary> findByTitleLike(String title, Pageable pageable) {
+    public Page<CordelSummary> findPublishedByTitleLike(boolean published, String title, Pageable pageable) {
 
         StringBuilder sql = new StringBuilder(CORDEL_SUMMARY);
         StringBuilder countSql = new StringBuilder(COUNT_CORDEL_SUMMARY);
@@ -106,15 +111,17 @@ class CustomCordelRepositoryImpl implements CustomCordelRepository {
         TypedQuery<CordelSummary> query = entityManager.createQuery(sql.toString(), CordelSummary.class);
 
         if(isAValidString(title)){
-            query = createQueryWithTitle(title, sql, CordelSummary.class);
-            countQuery = createQueryWithTitle(title, countSql, Long.class);
+            query = addTitleFilter(title, sql, CordelSummary.class);
+            countQuery = addTitleFilter(title, countSql, Long.class);
         }
 
+        countQuery.setParameter(PUBLISHED, published);
         Long count = countQuery.getSingleResult();
         if(count == 0) return Page.empty(pageable);
 
         query.setMaxResults(pageable.getPageSize());
         query.setFirstResult((int)pageable.getOffset());
+        query.setParameter(PUBLISHED, published);
 
         List<CordelSummary> resultList = query.getResultList();
 
@@ -125,8 +132,8 @@ class CustomCordelRepositoryImpl implements CustomCordelRepository {
         return title != null && title.length() >= MINIMUM_SIZE;
     }
 
-    private <T> TypedQuery<T> createQueryWithTitle(String title, StringBuilder sql, Class<T> clazz) {
-        String where = " WHERE lower(c.title) LIKE lower( :title )";
+    private <T> TypedQuery<T> addTitleFilter(String title, StringBuilder sql, Class<T> clazz) {
+        String where = " AND lower(c.title) LIKE lower( :title ) ";
         TypedQuery<T> query;
         sql.append(where);
         query = entityManager.createQuery(sql.toString(), clazz);

--- a/src/main/java/br/com/itsmemario/ecordel/security/AuthenticationController.java
+++ b/src/main/java/br/com/itsmemario/ecordel/security/AuthenticationController.java
@@ -52,7 +52,7 @@ public class AuthenticationController {
 	@PostMapping
 	public ResponseEntity<TokenDto> authenticate(@RequestBody @Valid LoginData data){
 		
-		logger.info("Username and password {} ***", data.getUsername());
+		logger.info("Login attempt");
 		
 		try {
 			UsernamePasswordAuthenticationToken authenticationToken = data.toAuthenticationToken();

--- a/src/main/java/br/com/itsmemario/ecordel/security/TokenAuthenticationFilter.java
+++ b/src/main/java/br/com/itsmemario/ecordel/security/TokenAuthenticationFilter.java
@@ -51,7 +51,7 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter{
 		if(isValidToken(token)) {
 			authorizeRequestWithToken(token.get());
 		}
-		
+			
 		filterChain.doFilter(request, response);
 		
 	}

--- a/src/main/resources/db/migration/V1.1__add-published-field.sql
+++ b/src/main/resources/db/migration/V1.1__add-published-field.sql
@@ -1,0 +1,8 @@
+-- schema definition v1
+--
+-- Copyright 2021 Projeto e-cordel.
+-- e-cordel project (http://www.ecordel.com.br/).
+
+alter table public.cordel add column published boolean not null default false;
+
+update public.cordel set published = true;

--- a/src/test/java/br/com/itsmemario/ecordel/AbstractIntegrationTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/AbstractIntegrationTest.java
@@ -21,7 +21,6 @@ public class AbstractIntegrationTest {
 
         private static void startContainers() {
             Startables.deepStart(Stream.of(postgres)).join();
-            // we can add further containers
         }
 
         private static Map<String, String> createConnectionConfiguration() {

--- a/src/test/java/br/com/itsmemario/ecordel/EcordelApplicationTests.java
+++ b/src/test/java/br/com/itsmemario/ecordel/EcordelApplicationTests.java
@@ -1,16 +1,24 @@
 package br.com.itsmemario.ecordel;
 
+import br.com.itsmemario.ecordel.cordel.CordelService;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class EcordelApplicationTests extends AbstractIntegrationTest{
 
+	@Autowired
+	CordelService service;
+
 	@Test
 	public void contextLoads() {
+		assertThat(service).isNotNull();
 	}
 
 }

--- a/src/test/java/br/com/itsmemario/ecordel/EcordelApplicationTests.java
+++ b/src/test/java/br/com/itsmemario/ecordel/EcordelApplicationTests.java
@@ -1,11 +1,11 @@
 package br.com.itsmemario.ecordel;
 
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class EcordelApplicationTests extends AbstractIntegrationTest{
 

--- a/src/test/java/br/com/itsmemario/ecordel/cordel/CordelControllerTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/cordel/CordelControllerTest.java
@@ -4,11 +4,11 @@ import br.com.itsmemario.ecordel.security.AuthenticationService;
 import br.com.itsmemario.ecordel.xilogravura.XilogravuraService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.Collections;
@@ -18,7 +18,7 @@ import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @WebMvcTest(CordelController.class)
 public class CordelControllerTest {
 

--- a/src/test/java/br/com/itsmemario/ecordel/cordel/CordelControllerTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/cordel/CordelControllerTest.java
@@ -1,55 +1,88 @@
 package br.com.itsmemario.ecordel.cordel;
 
-import br.com.itsmemario.ecordel.security.AuthenticationService;
-import br.com.itsmemario.ecordel.xilogravura.XilogravuraService;
-import org.junit.jupiter.api.BeforeEach;
+import br.com.itsmemario.ecordel.AbstractIntegrationTest;
+import br.com.itsmemario.ecordel.author.Author;
+import br.com.itsmemario.ecordel.author.AuthorRepository;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
-import java.util.Collections;
-import java.util.Optional;
+import java.util.Map;
 
-import static org.mockito.Mockito.when;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static br.com.itsmemario.ecordel.cordel.CordelUtil.newCordel;
+import static org.assertj.core.api.Assertions.assertThat;
 
-@ExtendWith(SpringExtension.class)
-@WebMvcTest(CordelController.class)
-public class CordelControllerTest {
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+public class CordelControllerTest extends AbstractIntegrationTest {
+
+    @LocalServerPort
+    private int port;
 
     @Autowired
-    MockMvc mockMvc;
+    private TestRestTemplate restTemplate;
 
-    @MockBean
-    CordelService cordelService;
+    @Autowired
+    CordelRepository cordelRepository;
 
-    @MockBean
-    XilogravuraService xilogravuraService;
+    @Autowired
+    AuthorRepository authorRepository;
 
-    @MockBean
-    AuthenticationService authenticationService;
 
-    private Cordel cordel;
+    @AfterEach
+    public void tearDown() {
+        cordelRepository.deleteAll();
+        authorRepository.deleteAll();
+    }
 
-    @BeforeEach
-    public void setUp() throws Exception {
-        cordel = new Cordel();
-        cordel.setId(1L);
-        cordel.setContent("");
-        cordel.setTitle("");
-        cordel.setTags(Collections.emptySet());
-        cordel.setDescription("");
+    public Cordel insertCordel(boolean published) {
+        Author author = authorRepository.save(new Author());
+        var cordel = newCordel(published, author);
+        return cordelRepository.save(cordel);
     }
 
     @Test
-    public void getCordel() throws Exception {
-        when(cordelService.findById(1l)).thenReturn(Optional.of(cordel));
-        mockMvc.perform(get("/cordels/1"))
-                .andExpect(status().isOk());
+    public void ifACordelExists_ItMustReturnOkAndTheCordel() {
+        Cordel cordel = insertCordel(true);
+
+        ResponseEntity<Cordel> forEntity = restTemplate.getForEntity(getBaseUrl() + "/{id}", Cordel.class, cordel.getId());
+
+        assertThat(forEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(forEntity.getBody()).hasFieldOrPropertyWithValue("content", cordel.getContent());
+    }
+
+    @Test
+    public void ifACordelDoesNotExists_ItMustReturn404() {
+        Long id = 100l;
+
+        ResponseEntity<Cordel> forEntity = restTemplate.getForEntity(getBaseUrl() + "/{id}", Cordel.class, id);
+
+        assertThat(forEntity.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    void ifPublishedParamIsFalse_theOnlyDraftCordelsMustBeRetrieved() {
+        insertCordel(false);
+
+        ResponseEntity<Map> response = restTemplate.getForEntity(getBaseUrl()+"?published=false", Map.class);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(1);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    @Test
+    void ifPublishedParamIsNotInformed_itMustBeConsideredTrue() {
+        insertCordel(true);
+
+        ResponseEntity<Map> response = restTemplate.getForEntity(getBaseUrl(), Map.class);
+        assertThat(response.getBody().get("totalElements")).isEqualTo(1);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    private String getBaseUrl() {
+        return "http://localhost:" + port + "/cordels";
     }
 }

--- a/src/test/java/br/com/itsmemario/ecordel/cordel/CordelControllerTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/cordel/CordelControllerTest.java
@@ -18,7 +18,7 @@ import static br.com.itsmemario.ecordel.cordel.CordelUtil.newCordel;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
-public class CordelControllerTest extends AbstractIntegrationTest {
+class CordelControllerTest extends AbstractIntegrationTest {
 
     @LocalServerPort
     private int port;
@@ -34,19 +34,19 @@ public class CordelControllerTest extends AbstractIntegrationTest {
 
 
     @AfterEach
-    public void tearDown() {
+    void tearDown() {
         cordelRepository.deleteAll();
         authorRepository.deleteAll();
     }
 
-    public Cordel insertCordel(boolean published) {
+    Cordel insertCordel(boolean published) {
         Author author = authorRepository.save(new Author());
         var cordel = newCordel(published, author);
         return cordelRepository.save(cordel);
     }
 
     @Test
-    public void ifACordelExists_ItMustReturnOkAndTheCordel() {
+    void ifACordelExists_ItMustReturnOkAndTheCordel() {
         Cordel cordel = insertCordel(true);
 
         ResponseEntity<Cordel> forEntity = restTemplate.getForEntity(getBaseUrl() + "/{id}", Cordel.class, cordel.getId());
@@ -56,7 +56,7 @@ public class CordelControllerTest extends AbstractIntegrationTest {
     }
 
     @Test
-    public void ifACordelDoesNotExists_ItMustReturn404() {
+    void ifACordelDoesNotExists_ItMustReturn404() {
         Long id = 100l;
 
         ResponseEntity<Cordel> forEntity = restTemplate.getForEntity(getBaseUrl() + "/{id}", Cordel.class, id);
@@ -69,7 +69,7 @@ public class CordelControllerTest extends AbstractIntegrationTest {
         insertCordel(false);
 
         ResponseEntity<Map> response = restTemplate.getForEntity(getBaseUrl()+"?published=false", Map.class);
-        assertThat(response.getBody().get("totalElements")).isEqualTo(1);
+        assertThat(response.getBody()).containsEntry("totalElements",1);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 
@@ -78,7 +78,7 @@ public class CordelControllerTest extends AbstractIntegrationTest {
         insertCordel(true);
 
         ResponseEntity<Map> response = restTemplate.getForEntity(getBaseUrl(), Map.class);
-        assertThat(response.getBody().get("totalElements")).isEqualTo(1);
+        assertThat(response.getBody()).containsEntry("totalElements",1);
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
     }
 

--- a/src/test/java/br/com/itsmemario/ecordel/cordel/CordelDtoTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/cordel/CordelDtoTest.java
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Projeto e-cordel (http://ecordel.com.br)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package br.com.itsmemario.ecordel.cordel;
+
+import br.com.itsmemario.ecordel.author.AuthorDto;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+class CordelDtoTest {
+
+    @Test
+    void toEntity() {
+        var dto = new CordelDto();
+        AuthorDto author = new AuthorDto();
+        author.setId(1l);
+        dto.setAuthor(author);
+        dto.setTitle("title");
+        dto.setContent("content");
+        dto.setDescription("description");
+        dto.setId(1l);
+        dto.setPublished(true);
+        dto.setTags(Collections.emptySet());
+        var cordel = dto.toEntity();
+
+        assertAll(
+                () -> assertThat(dto.getAuthor().getId()).isEqualTo(cordel.getAuthor().getId()),
+                () -> assertThat(dto.getContent()).isEqualTo(cordel.getContent()),
+                () -> assertThat(dto.getDescription()).isEqualTo(cordel.getDescription()),
+                () -> assertThat(dto.getId()).isEqualTo(cordel.getId()),
+                () -> assertThat(dto.getTitle()).isEqualTo(cordel.getTitle()),
+                () -> assertThat(dto.getTags()).isEqualTo(cordel.getTags())
+        );
+    }
+}

--- a/src/test/java/br/com/itsmemario/ecordel/cordel/CordelRepositoryTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/cordel/CordelRepositoryTest.java
@@ -4,15 +4,14 @@ import br.com.itsmemario.ecordel.AbstractIntegrationTest;
 import br.com.itsmemario.ecordel.author.Author;
 import br.com.itsmemario.ecordel.author.AuthorRepository;
 import org.junit.jupiter.api.AfterEach;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -21,10 +20,11 @@ import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class CordelRepositoryTest extends AbstractIntegrationTest {
 
@@ -34,22 +34,16 @@ public class CordelRepositoryTest extends AbstractIntegrationTest {
 
     @Autowired
     AuthorRepository authorRepository;
-    private Long id;
 
-    @BeforeEach
-    public void insertNewCordel() throws Exception {
-        Author author = authorRepository.save(new Author());
-        Cordel cordel = new Cordel();
-        cordel.setDescription("description");
-        cordel.setTitle("title");
-        cordel.setAuthor(author);
-        cordel.setContent("content");
-        cordel.setTags(new HashSet<>(Arrays.asList("tag1","tag2")));
-        id = repository.save(cordel).getId();
+    @AfterEach
+    void deleteAllCordels() throws Exception {
+        repository.deleteAll();
     }
 
     @Test
-    public void saveBigTextAsContent() throws IOException {
+    void saveBigTextAsContent() throws IOException {
+        Long id = insertNewCordel(true);
+
         Cordel byId = repository.findById(id).get();
         String lines = Files.readAllLines(BIG_FILE).stream().collect(Collectors.joining());
         byId.setContent(lines);
@@ -61,43 +55,62 @@ public class CordelRepositoryTest extends AbstractIntegrationTest {
                 .extracting(Cordel::getContent).asString().isNotEmpty();
     }
 
-    @AfterEach
-    public void deleteAllCordels() throws Exception {
-        repository.deleteAll();
-    }
-
     @Test
-    public void findAllProjectedBy() {
+    void findAllProjectedBy() {
+        insertNewCordel(true);
         Page<CordelView> cordelSummaries = repository.findAllProjectedBy(Pageable.unpaged());
         assertThat(cordelSummaries).isNotEmpty();
         assertThat(cordelSummaries.getContent().get(0)).isInstanceOf(CordelView.class);
     }
 
     @Test
-    public void findByTagsProjectedBy() {
+    void findByTagsProjectedBy() {
+        insertNewCordel(true);
         Page<CordelView> cordels = repository.findByTags(Arrays.asList("tag1", "tag2"), PageRequest.of(0,1));
         assertThat(cordels).hasSize(1);
         assertThat(cordels.getContent().get(0)).extracting(CordelView::getDescription).isEqualTo("description");
     }
 
     @Test
-    public void findByTitleLike() {
-        Page<CordelSummary> page = repository.findByTitleLike("tit", PageRequest.of(0,10));
+    void findByPublishedTitleLike() {
+        insertNewCordel(true);
+        Page<CordelSummary> page = repository.findPublishedByTitleLike(true, "tit", PageRequest.of(0,10));
         page.getContent().forEach(cordel -> System.out.println(cordel.getTitle()));
         assertThat(page).hasSize(1);
 
-        page = repository.findByTitleLike("aaa", PageRequest.of(0,10));
+        page = repository.findPublishedByTitleLike(true, "aaa", PageRequest.of(0,10));
         assertThat(page).hasSize(0);
     }
 
     @Test
-    public void testPaginationResultsByTitle() throws Exception {
-        deleteAllCordels();
-        for(int i = 0; i<5;i++) insertNewCordel();
+    void testPaginationResultsByPublishedTitle() throws Exception {
+        IntStream.range(0,5).forEach( i -> insertNewCordel(true));
 
-        Page<CordelSummary> page = repository.findByTitleLike("tit", PageRequest.of(1,3));
+        Page<CordelSummary> page = repository.findPublishedByTitleLike(true, "tit", PageRequest.of(1,3));
         page.getContent().forEach(cordel -> System.out.println(cordel.getTitle()));
         assertThat(page).hasSize(2);
+    }
+
+    @Test
+    void findNotPublishedWorkTest() {
+        insertNewCordel(false);
+        Page<CordelSummary> page = repository.findPublishedByTitleLike(true, "tit", PageRequest.of(0, 10));
+        assertThat(page).isEmpty();
+
+        page = repository.findPublishedByTitleLike(false, "tit", PageRequest.of(0, 10));
+        assertThat(page).isNotEmpty().hasSize(1);
+    }
+
+    Long insertNewCordel(boolean published) {
+        Author author = authorRepository.save(new Author());
+        Cordel cordel = new Cordel();
+        cordel.setDescription("description");
+        cordel.setTitle("title");
+        cordel.setAuthor(author);
+        cordel.setContent("content");
+        cordel.setPublished(published);
+        cordel.setTags(new HashSet<>(Arrays.asList("tag1","tag2")));
+        return repository.save(cordel).getId();
     }
 
 }

--- a/src/test/java/br/com/itsmemario/ecordel/cordel/CordelRepositoryTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/cordel/CordelRepositoryTest.java
@@ -18,10 +18,10 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
+import static br.com.itsmemario.ecordel.cordel.CordelUtil.newCordel;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @ExtendWith(SpringExtension.class)
@@ -29,6 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class CordelRepositoryTest extends AbstractIntegrationTest {
 
     private static final Path BIG_FILE = Paths.get("src/test/resources/content.txt");
+
     @Autowired
     CordelRepository repository;
 
@@ -36,7 +37,7 @@ public class CordelRepositoryTest extends AbstractIntegrationTest {
     AuthorRepository authorRepository;
 
     @AfterEach
-    void deleteAllCordels() throws Exception {
+    void deleteAllCordels() {
         repository.deleteAll();
     }
 
@@ -102,14 +103,8 @@ public class CordelRepositoryTest extends AbstractIntegrationTest {
     }
 
     Long insertNewCordel(boolean published) {
-        Author author = authorRepository.save(new Author());
-        Cordel cordel = new Cordel();
-        cordel.setDescription("description");
-        cordel.setTitle("title");
-        cordel.setAuthor(author);
-        cordel.setContent("content");
-        cordel.setPublished(published);
-        cordel.setTags(new HashSet<>(Arrays.asList("tag1","tag2")));
+        var author = authorRepository.save(new Author());
+        var cordel = newCordel(published, author);
         return repository.save(cordel).getId();
     }
 

--- a/src/test/java/br/com/itsmemario/ecordel/cordel/CordelUtil.java
+++ b/src/test/java/br/com/itsmemario/ecordel/cordel/CordelUtil.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 Projeto e-cordel (http://ecordel.com.br)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package br.com.itsmemario.ecordel.cordel;
+
+import br.com.itsmemario.ecordel.author.Author;
+
+import java.util.Arrays;
+import java.util.HashSet;
+
+public class CordelUtil {
+
+    private CordelUtil() {}
+
+    public static Cordel newCordel(boolean published, Author author) {
+        var cordel = new Cordel();
+        cordel.setDescription("description");
+        cordel.setAuthor(author);
+        cordel.setTitle("title");
+        cordel.setContent("content");
+        cordel.setPublished(published);
+        cordel.setTags(new HashSet<>(Arrays.asList("tag1","tag2")));
+        return cordel;
+    }
+}

--- a/src/test/java/br/com/itsmemario/ecordel/security/AuthenticationControllerTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/security/AuthenticationControllerTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2021 Projeto e-cordel (http://ecordel.com.br)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package br.com.itsmemario.ecordel.security;
+
+import br.com.itsmemario.ecordel.AbstractIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class AuthenticationControllerTest extends AbstractIntegrationTest {
+
+    @LocalServerPort
+    private int port;
+
+    @Autowired
+    private TestRestTemplate restTemplate;
+
+    @Autowired
+    UserRepository repository;
+
+    @Test
+    void authenticateWithCorrectCredentials() {
+        var test = "test";
+        var pass = new BCryptPasswordEncoder().encode(test);
+        var cordelUser = new CordelUser(test,pass);
+        repository.save(cordelUser);
+
+        var url =  "http://localhost:" + port + "/auth";
+        ResponseEntity<TokenDto> response = restTemplate.postForEntity(url, new LoginData(test, test), TokenDto.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).extracting("token").isNotNull();
+    }
+}

--- a/src/test/java/br/com/itsmemario/ecordel/xilogravura/XilogravuraRepositoryTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/xilogravura/XilogravuraRepositoryTest.java
@@ -3,14 +3,14 @@ package br.com.itsmemario.ecordel.xilogravura;
 
 import br.com.itsmemario.ecordel.AbstractIntegrationTest;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class XilogravuraRepositoryTest extends AbstractIntegrationTest {
 

--- a/src/test/java/br/com/itsmemario/ecordel/xilogravura/XilogravuraServiceTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/xilogravura/XilogravuraServiceTest.java
@@ -5,7 +5,7 @@ import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockftpserver.fake.FakeFtpServer;
 import org.mockftpserver.fake.UserAccount;
 import org.mockftpserver.fake.filesystem.DirectoryEntry;
@@ -15,13 +15,13 @@ import org.mockftpserver.fake.filesystem.UnixFakeFileSystem;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.mock.web.MockMultipartFile;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.io.IOException;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class XilogravuraServiceTest extends AbstractIntegrationTest {
 


### PR DESCRIPTION
# Published field

Cordel passa a ter um campo `published` que será usado como uma flag.
Os codéis scraped serão cadastrados com `published=false` para que seja possível revisá-los antes.

## Alterações

 - Repositório filtra por publicados
 - Foi alterado o GET /cordels para incluir um o parâmetro na API também
 - openapi spec
 - incluído dto para cordel
 - incluído tests ao cordelcontroller


