### PR TITLE
Fix author vulnerability with AuthorDto

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,9 @@ Add in VMArguments to run in a IDE
 
 You can run with maven
 
-    mvn spring-boot:run
+    mvn spring-boot:run -Dspring-boot.run.profiles=local
 
-or, you can run with docker if you already hava a image
+or, you can run with docker if you already have an image
 
     docker container run --name ecordel --rm -p 8080:8080 ecordel-restapi:1
 
@@ -41,6 +41,10 @@ tip: --rm parameter will exclude container image after execution and it cause da
 ## How to test
 
     mvn test
+    
+### Writing Tests
+
+If you wanna use db connection on your test you must extend the class `AbstractIntegrationTest`. This class will run the docker container and configure the spring datasource. 
 
 ## How to contribute
 

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.5</version>
+        <version>2.5.1</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -56,6 +56,11 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
         </dependency>
 
         <dependency>
@@ -121,6 +126,13 @@
             <groupId>org.mockftpserver</groupId>
             <artifactId>MockFtpServer</artifactId>
             <version>${mockftp.version}</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.5</version>
             <scope>test</scope>
         </dependency>
 

--- a/src/main/java/br/com/itsmemario/ecordel/author/Author.java
+++ b/src/main/java/br/com/itsmemario/ecordel/author/Author.java
@@ -17,10 +17,7 @@
 
 package br.com.itsmemario.ecordel.author;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import javax.persistence.*;
 
 @Entity
 public class Author implements AuthorView {
@@ -28,14 +25,23 @@ public class Author implements AuthorView {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
+    @Column( nullable = false )
     private String name;
     private String about;
     private String email;
 
-    public static Author of( Long id, String about ) {
+    /**
+     * Default constructor used by JPA
+     */
+    Author() {}
+
+    public Author(String name) {
+        this.name = name;
+    }
+
+    public static Author of(Long id ) {
         var author = new Author();
         author.id = id;
-        author.about = about;
         return author;
     }
 

--- a/src/main/java/br/com/itsmemario/ecordel/author/AuthorController.java
+++ b/src/main/java/br/com/itsmemario/ecordel/author/AuthorController.java
@@ -43,8 +43,8 @@ public class AuthorController {
     }
 
     @PostMapping
-    public ResponseEntity<Author> newAuthor(@RequestBody @Valid Author author, UriComponentsBuilder uriBuilder){
-        service.save(author);
+    public ResponseEntity<Author> newAuthor(@RequestBody @Valid AuthorDto author, UriComponentsBuilder uriBuilder){
+        service.save(author.toEntity());
         URI uri = uriBuilder.path("/authors/{id}").buildAndExpand(author.getId()).toUri();
         return ResponseEntity.created(uri).build();
     }

--- a/src/main/java/br/com/itsmemario/ecordel/author/AuthorDto.java
+++ b/src/main/java/br/com/itsmemario/ecordel/author/AuthorDto.java
@@ -19,16 +19,23 @@ package br.com.itsmemario.ecordel.author;
 
 import lombok.Data;
 
+import javax.validation.constraints.NotNull;
+
 @Data
 public class AuthorDto {
 
     private Long id;
     private String about;
+    @NotNull
+    private String name;
+    private String email;
 
     public Author toEntity() {
         var author = new Author();
         author.setId(id);
         author.setAbout(about);
+        author.setName(name);
+        author.setEmail(email);
         return author;
     }
 }

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CustomCordelRepositoryImpl.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CustomCordelRepositoryImpl.java
@@ -94,8 +94,7 @@ class CustomCordelRepositoryImpl implements CustomCordelRepository {
     }
 
     private Author buildAuthor(Object name, Object email) {
-        Author author = new Author();
-        author.setName(String.valueOf(name));
+        Author author = new Author(String.valueOf(name));
         author.setEmail(String.valueOf(email));
         return author;
     }

--- a/src/main/resources/db/migration/V1.2__author-type-changed-field.sql
+++ b/src/main/resources/db/migration/V1.2__author-type-changed-field.sql
@@ -5,4 +5,4 @@
 
 ALTER TABLE public.author ALTER COLUMN about TYPE text;
 
-
+ALTER TABLE public.author ALTER COLUMN name SET NOT NULL;

--- a/src/test/java/br/com/itsmemario/ecordel/AbstractIntegrationTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/AbstractIntegrationTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2021 Projeto e-cordel (http://ecordel.com.br)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package br.com.itsmemario.ecordel;
 
 import org.springframework.context.ApplicationContextInitializer;
@@ -31,20 +48,14 @@ public class AbstractIntegrationTest {
             return map;
         }
 
-
         @Override
-        public void initialize(
-                ConfigurableApplicationContext applicationContext) {
-
+        public void initialize(ConfigurableApplicationContext applicationContext) {
             startContainers();
-
             ConfigurableEnvironment environment = applicationContext.getEnvironment();
-
             MapPropertySource testcontainers = new MapPropertySource(
                     "testcontainers",
                     (Map) createConnectionConfiguration()
             );
-
             environment.getPropertySources().addFirst(testcontainers);
         }
     }

--- a/src/test/java/br/com/itsmemario/ecordel/EcordelApplicationTests.java
+++ b/src/test/java/br/com/itsmemario/ecordel/EcordelApplicationTests.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2021 Projeto e-cordel (http://ecordel.com.br)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package br.com.itsmemario.ecordel;
 
 import br.com.itsmemario.ecordel.cordel.CordelService;

--- a/src/test/java/br/com/itsmemario/ecordel/author/AuthorControllerTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/author/AuthorControllerTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2021 Projeto e-cordel (http://ecordel.com.br)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package br.com.itsmemario.ecordel.author;
+
+import br.com.itsmemario.ecordel.AbstractIntegrationTest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.jwt;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+class AuthorControllerTest extends AbstractIntegrationTest {
+
+    public static final String AUTHORS = "/authors";
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Test
+    void requestWithoutValidTokenMustReturnStatusCodeForbidden() throws Exception {
+        mockMvc.perform(post(AUTHORS)).andExpect(status().isForbidden());
+    }
+
+    @Test
+    void requestWithValidTokenMustReturnStatusCodeCreated() throws Exception {
+        AuthorDto dto = new AuthorDto();
+        dto.setName("name");
+        String json = new ObjectMapper().writer().writeValueAsString(dto);
+        mockMvc.perform(
+                post("/authors")
+                        .with(jwt())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(json)
+        ).andExpect(status().isCreated());
+    }
+
+    @Test
+    void getAuthorsReturnStatusCodeOK() throws Exception {
+        mockMvc.perform(get(AUTHORS)).andExpect(status().isOk());
+    }
+}

--- a/src/test/java/br/com/itsmemario/ecordel/author/AuthorDtoTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/author/AuthorDtoTest.java
@@ -22,19 +22,23 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-public class AuthorDtoTest {
+class AuthorDtoTest {
 
     @Test
     void toEntity() {
-        AuthorDto authorDto = new AuthorDto();
+        var authorDto = new AuthorDto();
         authorDto.setId(1L);
         authorDto.setAbout("about the author");
+        authorDto.setEmail("email");
+        authorDto.setName("name");
 
         Author author = authorDto.toEntity();
 
         assertAll(
                 () -> assertThat(author.getId()).isEqualTo(authorDto.getId()),
-                () -> assertThat(author.getAbout()).isEqualTo(authorDto.getAbout())
+                () -> assertThat(author.getAbout()).isEqualTo(authorDto.getAbout()),
+                () -> assertThat(author.getEmail()).isEqualTo(authorDto.getEmail()),
+                () -> assertThat(author.getName()).isEqualTo(authorDto.getName())
         );
     }
 }

--- a/src/test/java/br/com/itsmemario/ecordel/author/AuthorRepositoryTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/author/AuthorRepositoryTest.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2021 Projeto e-cordel (http://ecordel.com.br)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package br.com.itsmemario.ecordel.author;
+
+import br.com.itsmemario.ecordel.AbstractIntegrationTest;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.testcontainers.shaded.org.apache.commons.lang.RandomStringUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+@Slf4j
+@SpringBootTest
+class AuthorRepositoryTest extends AbstractIntegrationTest {
+
+    @Autowired
+    AuthorRepository repository;
+
+    @Test
+    void shouldSaveAnAuthorWithAboutTextBiggerThan255() {
+        Author author = new Author();
+        String longText = RandomStringUtils.randomAlphabetic(500);
+        log.info("Long text: {}", longText);
+        author.setName("name");
+        author.setAbout(longText);
+
+        Author saved = repository.save(author);
+
+        assertAll(
+                () -> assertThat(saved).isNotNull(),
+                () -> assertThat(saved.getAbout()).isNotEmpty().isEqualTo(longText)
+        );
+
+    }
+
+}

--- a/src/test/java/br/com/itsmemario/ecordel/cordel/CordelControllerTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/cordel/CordelControllerTest.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2021 Projeto e-cordel (http://ecordel.com.br)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *  http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
 package br.com.itsmemario.ecordel.cordel;
 
 import br.com.itsmemario.ecordel.AbstractIntegrationTest;
@@ -40,7 +57,7 @@ class CordelControllerTest extends AbstractIntegrationTest {
     }
 
     Cordel insertCordel(boolean published) {
-        Author author = authorRepository.save(new Author());
+        Author author = authorRepository.save(new Author("name"));
         var cordel = newCordel(published, author);
         return cordelRepository.save(cordel);
     }

--- a/src/test/java/br/com/itsmemario/ecordel/cordel/CordelRepositoryTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/cordel/CordelRepositoryTest.java
@@ -103,7 +103,7 @@ public class CordelRepositoryTest extends AbstractIntegrationTest {
     }
 
     Long insertNewCordel(boolean published) {
-        var author = authorRepository.save(new Author());
+        var author = authorRepository.save(new Author("name"));
         var cordel = newCordel(published, author);
         return repository.save(cordel).getId();
     }


### PR DESCRIPTION
Usa authorDto como parâmetro para `/POST authors` ao invés da entidade.

Alterações

 - AuthorController
 - Add mais testes para os códigos de retorno http
 - Add test para persistência de autor com campo `about` maior que 255 caracteres


