### PR TITLE
Download ecordel in .txt format

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -172,6 +172,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Cordel'
+            text/plain:
+              schema:
+                  type: string
         404:
           description: "Not found"
       tags:

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.3.4</version>
+        <version>3.4.1</version>
         <relativePath /> <!-- lookup parent from repository -->
     </parent>
 
@@ -142,6 +142,12 @@
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok-mapstruct-binding</artifactId>
             <version>${lombok-mapstruct-binding.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.github.spullara.mustache.java</groupId>
+            <artifactId>compiler</artifactId>
+            <version>0.9.10</version>
         </dependency>
 
         <!-- test dependencies-->

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CordelController.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CordelController.java
@@ -69,13 +69,13 @@ public class CordelController {
   @GetMapping(value = "{id}", produces = MediaType.TEXT_PLAIN_VALUE)
   public ResponseEntity<InputStreamResource> downloadTxt(@PathVariable Long id) {
     var cordelDto = service.getContentForDownload(id);
-
-    var inputStreamResource = new InputStreamResource(new ByteArrayInputStream(cordelDto.getContent().getBytes()));
+    var contentBytes = cordelDto.getContent().getBytes();
+    var inputStreamResource = new InputStreamResource(new ByteArrayInputStream(contentBytes));
 
     return ResponseEntity.ok()
             .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + cordelDto.getTitle() + ".txt\"")
             .contentType(MediaType.TEXT_PLAIN)
-            .contentLength(cordelDto.getContent().length())
+            .contentLength(contentBytes.length)
             .body(inputStreamResource);
   }
 

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CordelDto.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CordelDto.java
@@ -21,12 +21,14 @@ import br.com.itsmemario.ecordel.author.AuthorDto;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.Set;
+import lombok.Builder;
 import lombok.Data;
 
 /**
  * Class used to represent data sent do the backend.
  */
 @Data
+@Builder
 public class CordelDto {
 
   private Long id;

--- a/src/main/java/br/com/itsmemario/ecordel/cordel/CordelNotFoundException.java
+++ b/src/main/java/br/com/itsmemario/ecordel/cordel/CordelNotFoundException.java
@@ -20,7 +20,7 @@ package br.com.itsmemario.ecordel.cordel;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.bind.annotation.ResponseStatus;
 
-@ResponseStatus(value= HttpStatus.NOT_FOUND, reason="Cordel not found")
+@ResponseStatus(value = HttpStatus.NOT_FOUND, reason = "Cordel not found")
 public class CordelNotFoundException extends RuntimeException {
 
 }

--- a/src/main/java/br/com/itsmemario/ecordel/security/SecurityConfig.java
+++ b/src/main/java/br/com/itsmemario/ecordel/security/SecurityConfig.java
@@ -97,6 +97,8 @@ public class SecurityConfig {
   CorsConfigurationSource corsConfigurationSource() {
     CorsConfiguration configuration = new CorsConfiguration();
     configuration.setAllowedOrigins(Collections.singletonList("*"));
+    // allow download, it will be included in the response header Access-Control-Expose-Headers
+    configuration.addExposedHeader(HttpHeaders.CONTENT_DISPOSITION);
     configuration.addExposedHeader(HttpHeaders.LOCATION);
     configuration.addAllowedHeader("*");
     configuration.addAllowedMethod("*");

--- a/src/main/resources/mustache/cordel.mustache
+++ b/src/main/resources/mustache/cordel.mustache
@@ -1,0 +1,22 @@
+Título: {{title}}
+{{#description}}
+Descrição: {{description}}
+{{/description}}
+{{#year}}
+Publicado em: {{year}}
+{{/year}}
+Autor: {{author.name}}
+
+Texto do cordel:
+{{content}}
+
+{{#source}}
+Fonte: {{source}}
+{{/source}}
+
+Conteúdo baixado através do site ler.ecordel.com.br
+
+E-cordel é um projeto de código aberto sem fins lucrativos criado no Cariri Cearense, 
+com intuito de preservar a literatura de cordel e potencializar a sua divulgação através da internet.
+Dessa forma, foi desenvolvida uma plataforma para registro e catalogação de cordéis digitais que pode ser acessada gratuitamente.
+Esta obra é também disponibilizada como um ebook para garantir que pessoas com necessidades especiais possam desfrutar da literatura de cordel.

--- a/src/test/java/br/com/itsmemario/ecordel/cordel/CordelServiceTest.java
+++ b/src/test/java/br/com/itsmemario/ecordel/cordel/CordelServiceTest.java
@@ -17,64 +17,75 @@
 
 package br.com.itsmemario.ecordel.cordel;
 
+import br.com.itsmemario.ecordel.author.Author;
 import br.com.itsmemario.ecordel.xilogravura.XilogravuraService;
+import java.util.Optional;
+import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
-import org.mockito.MockitoAnnotations;
+import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Pageable;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.when;
 
+@Slf4j
+@ExtendWith(MockitoExtension.class)
 class CordelServiceTest {
 
-    @Mock
-    private XilogravuraService xilogravuraService;
-    @Mock
-    private CordelRepository cordelRepository;
+  @Mock
+  private XilogravuraService xilogravuraService;
+  @Mock
+  private CordelRepository cordelRepository;
 
-    private final Pageable page = Pageable.unpaged();
-    private CordelService cordelService;
+  private final Pageable page = Pageable.unpaged();
+  private CordelService cordelService;
 
-    @BeforeEach
-    void setUp() {
-        MockitoAnnotations.openMocks(this);
-        cordelService = new CordelService(cordelRepository, xilogravuraService);
-    }
+  @BeforeEach
+  void setUp() {
+    cordelService = new CordelService(cordelRepository, xilogravuraService);
+  }
 
-    @Test
-    void testIfTitleIsInvalid_QueryOnlyByPublished() {
+  @Test
+  void testIfTitleIsInvalid_QueryOnlyByPublished() {
+    CordelSummaryRequest invalidRequest0 = CordelSummaryRequest.builder().published(true).title("").build();
+    CordelSummaryRequest invalidRequest1 = CordelSummaryRequest.builder().published(true).title(null).build();
 
-        //arrange
-        CordelSummaryRequest invalidRequest0 = CordelSummaryRequest.builder().published(true).title("").build();
-        CordelSummaryRequest invalidRequest1 = CordelSummaryRequest.builder().published(true).title(null).build();
+    cordelService.findPublishedByTitle(invalidRequest0, page);
+    cordelService.findPublishedByTitle(invalidRequest1, page);
 
-        //act
-        cordelService.findPublishedByTitle(invalidRequest0, page);
-        cordelService.findPublishedByTitle(invalidRequest1, page);
+    Mockito.verify(cordelRepository).findAllByPublished(invalidRequest0, page);
+    Mockito.verify(cordelRepository).findAllByPublished(invalidRequest1, page);
+    Mockito.verify(cordelRepository, times(0))
+            .findAllByPublishedAndTitleLike(invalidRequest0, page);
+  }
 
-        //test
-        Mockito.verify(cordelRepository).findAllByPublished(invalidRequest0, page);
-        Mockito.verify(cordelRepository).findAllByPublished(invalidRequest1, page);
-        Mockito.verify(cordelRepository, times(0))
-                .findAllByPublishedAndTitleLike(invalidRequest0, page);
+  @Test
+  void testIfTitleIsValid_QueryOnlyByPublishedAndTitleLike() {
+    CordelSummaryRequest validRequest0 = CordelSummaryRequest.builder().published(true).title("title").build();
 
+    cordelService.findPublishedByTitle(validRequest0, page);
 
-    }
+    Mockito.verify(cordelRepository).findAllByPublishedAndTitleLike(validRequest0, page);
+    Mockito.verify(cordelRepository, times(0)).findAllByPublished(validRequest0, page);
+  }
 
-    @Test
-    void testIfTitleIsValid_QueryOnlyByPublishedAndTitleLike() {
+  @Test
+  void shouldGenerateFormattedTextForDownload() {
+    Cordel cordel = CordelUtil.newCordel(true, new Author("Test"));
+    cordel.setYear(1999);
+    cordel.setSource("https://ler.ecordel.com.br");
+    when(cordelRepository.findById(1L)).thenReturn(Optional.of(cordel));
 
-        //arrange
-        CordelSummaryRequest validRequest0 = CordelSummaryRequest.builder().published(true).title("title").build();
+    CordelDto contentForDownload = cordelService.getContentForDownload(1L);
+    log.info("contentForDownload: {}", contentForDownload.getContent());
 
-        //act
-        cordelService.findPublishedByTitle(validRequest0, page);
-
-        //test
-        Mockito.verify(cordelRepository).findAllByPublishedAndTitleLike(validRequest0, page);
-        Mockito.verify(cordelRepository, times(0)).findAllByPublished(validRequest0, page);
-    }
-
+    assertThat(contentForDownload).isNotNull();
+    assertThat(contentForDownload.getTitle()).isEqualTo(cordel.getTitle());
+    assertThat(contentForDownload.getContent()).contains("Título: " + cordel.getTitle(), "Autor: Test", "Texto do cordel:", "ler.ecordel.com.br");
+  }
 }


### PR DESCRIPTION
# Download ecordel in .txt format

Add a new handler for requests that need text/plain.
The cordel txt is generated with mustache to allow us further customization.


